### PR TITLE
Swap W391 anti-pattern and best practice

### DIFF
--- a/_rules/W391.md
+++ b/_rules/W391.md
@@ -4,7 +4,7 @@ message: "Blank line at end of file"
 title: "Blank line at end of file (W391)"
 ---
 
-There should be one, and only one, blank line at the end of each file. This warning will occur when there are two or more blank lines.
+There should be one, and only one, blank line at the end of each file. This warning will occur when there are zero, two, or more than two blank lines.
 
 ### Anti-pattern
 
@@ -14,6 +14,8 @@ Imagine the example below is an entire file.
 class MyClass(object):
     pass
 
+
+
 ```
 
 ### Best practice
@@ -21,7 +23,5 @@ class MyClass(object):
 ```python
 class MyClass(object):
     pass
-
-
 
 ```


### PR DESCRIPTION
This PR resolves a typo in the W391 rule page, where anti-pattern and best practice were swapped. It also clarifies the description, where this warning appears when 0 blank lines exist at the end of a file.

Closes #11 