### PR TITLE
Fix W391 and W292 examples

### DIFF
--- a/_rules/W292.md
+++ b/_rules/W292.md
@@ -13,8 +13,7 @@ Imagine the example below is an entire file.
 ```python
 import os
 
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-```
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))```
 
 ### Best practice
 
@@ -24,5 +23,4 @@ Imagine the example below is an entire file.
 import os
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-
 ```

--- a/_rules/W391.md
+++ b/_rules/W391.md
@@ -23,5 +23,4 @@ class MyClass(object):
 ```python
 class MyClass(object):
     pass
-
 ```


### PR DESCRIPTION
Currently there are two new line characters at the end of 'Best practice' , and it contradicts with an actual flake8 behaviour:
```
$ python3 -m flake8 test.py
test.py:3:1: W391 blank line at end of file
```
```
$ cat -e test.py
class MyClass(object):$
    pass$
$
```
```
$ cat -E _rules/W391.md
---$
code: W391$
message: "Blank line at end of file"$
title: "Blank line at end of file (W391)"$
---$
$
There should be one, and only one, blank line at the end of each file. This warning will occur when there are zero, two, or more than two blank lines.$
$
### Anti-pattern$
$
Imagine the example below is an entire file.$
$
```python$
class MyClass(object):$
    pass$
$
$
$
```$
$
### Best practice$
$
```python$
class MyClass(object):$
    pass$
```$

```
