### PR TITLE
Update E306.md

### DIFF
--- a/_rules/E306.md
+++ b/_rules/E306.md
@@ -11,16 +11,20 @@ Nested functions should contain 1 blank line between their definitions.
 ### Anti-pattern
 
 ```python
-def outer():
-    def inner():
+def foo():
+    def bar():
+        pass
+    def baz():
         pass
 ```
 
 ### Best practice
 
 ```python
-def outer():
+def foo():
+    def bar():
+        pass
 
-    def inner():
+    def baz():
         pass
 ```


### PR DESCRIPTION
This PR updates the `E306` to match the implementation of pycodestyle. 

The current example is incorrect, cf [this pycodestyle issue](https://github.com/PyCQA/pycodestyle/issues/1216).